### PR TITLE
READY: Handle nonexistent metadata.d in MetaSrc.

### DIFF
--- a/lib/ploy/metasrc.rb
+++ b/lib/ploy/metasrc.rb
@@ -5,6 +5,7 @@ module Ploy
     end
     def load
       d = {}
+      return {} unless Dir.exists? @dir
       Dir.foreach(@dir) do |fname|
         if (fname =~ /\.ya?ml$/) then
           y = YAML::load_file(File.join(@dir,fname))

--- a/spec/metasrc_spec.rb
+++ b/spec/metasrc_spec.rb
@@ -8,5 +8,11 @@ describe Ploy::MetaSrc do
       expect(data['some-project']).to be_a(Hash)
       expect(data['some-project']['name']).to eq('some-project')
     end
+    it "fails gracefully with an invalid directory" do
+      msrc = Ploy::MetaSrc.new("thisisnothere")
+      data = msrc.load
+      expect(data).to be_a(Hash)
+      expect(data.length).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Don't explode when metadata.d isn't there. Fixes #3 
