### PR TITLE
WIP: sketch solution for logrotate and other stuff

### DIFF
--- a/lib/ploy/localpackage/debbuilder.rb
+++ b/lib/ploy/localpackage/debbuilder.rb
@@ -10,8 +10,8 @@ module Ploy
       attr_accessor :branch
       attr_accessor :timestamp
       attr_accessor :upstart_files
-      attr_accessor :dist_dir
       attr_accessor :dist_dirs
+      attr_accessor :dist_dir
       attr_accessor :prefix
 
       def initialize(opts = {})


### PR DESCRIPTION
This code isn't tested and probably not working, but wanted to sketch out a solution for embedding files destined for /etc/logrotate.d and other arbitrary places. Changes allow:

```
dist_dirs:
  - dir: server
    prefix: /usr/local/manta-frontend
```

instead of

```
dist_dir: server
prefix: /usr/local/manta-frontend
```

with the idea of adding additional stanzas such as:

```
  - dir: logrotate.d
    prefix: /etc/logrotate.d
```

Let me know what you think of the approach/naming/etc.

/cc @reprehensible @mantacode/systems-engineering 
