### PR TITLE
READY: Fix tests for deprecation warnings

### DIFF
--- a/spec/command_install_spec.rb
+++ b/spec/command_install_spec.rb
@@ -3,10 +3,11 @@ require 'ploy/command/install'
 describe Ploy::Command::Install do
   describe "#run" do
     it "will run Package#install with correct arguments and return true" do
-      Ploy::Package.any_instance.should_receive(:install)
-      argv = ['-b', 'bucket', '-d', 'deploy', '-B', 'branch', '-v', 'version']
-      Ploy::Package.any_instance.should_receive(:check_new_version) { 'abcde' }
-      expect(Ploy::Command::Install.new.run(argv)).to be true
+      argv = ['-b', 'bucket', '-d', 'deploy', '-B', 'branch', '-v', 'version']      
+      expect_any_instance_of(Ploy::Package).to receive(:install)
+      expect_any_instance_of(Ploy::Package).to receive(:check_new_version).and_return('abcde')
+      expect(STDOUT).to receive(:puts).with('installed deploy')
+      expect(Ploy::Command::Install.new.run argv).to be true
     end
   end
   describe "#help" do

--- a/spec/command_publish_spec.rb
+++ b/spec/command_publish_spec.rb
@@ -4,12 +4,10 @@ describe Ploy::Command::Publish do
   describe "#run" do
     it "will run Publisher#publish with correct arguments and return true" do
       pub = double("publisher")
-      pub.should_receive(:publish) { [] }
-      Ploy::Publisher.should_receive(:new).with("test.yml") { pub }
-      subject = Ploy::Command::Publish.new
-      subject.stub(:is_pull_request_build) { false }
-      argv = ["test.yml"]
-      expect(subject.run(argv)).to be true
+      expect(pub).to receive(:publish).and_return([])
+      expect(Ploy::Publisher).to receive(:new).with('test.yml').and_return(pub)
+      expect_any_instance_of(Ploy::Command::Publish).to receive(:is_pull_request_build).and_return(false)
+      expect(Ploy::Command::Publish.new.run ['test.yml']).to be true
     end
   end
   describe "#help" do

--- a/spec/metaoracle_spec.rb
+++ b/spec/metaoracle_spec.rb
@@ -4,24 +4,19 @@ describe Ploy::MetaOracle do
   it 'can be initialized' do
     expect(Ploy::MetaOracle.new("test")).to be_a(Ploy::MetaOracle)
   end
-
   describe '#query' do
      # no interesting tests yet
   end
-
   describe '#meta' do
      # no interesting tests yet
   end
-
   describe '#oracle_uri' do
     it "returns the right url" do
-      fakeinstance = double('instance')
-      fakeinstance.stub(:private_ip_address) { '1.1.1.1' }
-
-      r = Ploy::MetaOracle.new("test").oracle_uri(fakeinstance)
+      fake_instance = double('instance')
+      expect(fake_instance).to receive(:private_ip_address).and_return('1.1.1.1')
+      r = Ploy::MetaOracle.new("test").oracle_uri(fake_instance)
       expect(r).to be_a(URI)
       expect(r.to_s).to eq('http://1.1.1.1:9876/')
     end
   end
-
 end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -2,69 +2,58 @@ require 'ploy/package'
 require 'ploy/common'
 
 describe Ploy::Package do
-  it "can be instantiated" do
-    inst = Ploy::Package.new("testbucket", "some-project", "master", "current")
-    expect(inst).to be_a Ploy::Package
-  end
   before(:all) do
     @inst = Ploy::Package.new("testbucket", "some-project", "master", "current")
   end
+  it "can be instantiated" do
+    expect(@inst).to be_a Ploy::Package
+  end
   describe '#install' do
     it "downloads and dpkg installs a file from s3" do
-      Ploy::S3Storage.any_instance.should_receive(:get)
-      Ploy::Package.any_instance.should_receive(:system).with(/^dpkg -i /)
+      expect_any_instance_of(Ploy::S3Storage).to receive(:get)
+      expect_any_instance_of(Ploy::Package).to receive(:system).with(/^dpkg -i /)
       @inst.install
     end
   end
   describe '#check_new_version' do
     it "compares the same local and remote versions" do
-      Ploy::Package.any_instance.should_receive(:`).with(/dpkg-query/) { "abcd\n" }
-      Ploy::S3Storage.any_instance.should_receive(:metadata) { { 'git_revision' => 'abcd' } }
+      expect_any_instance_of(Ploy::Package).to receive(:`).with(/dpkg-query/).and_return("abcd\n")
+      expect_any_instance_of(Ploy::S3Storage).to receive(:metadata).and_return({'git_revision' => 'abcd'})
       expect(@inst.check_new_version).to be false
     end
     it "compares different local and remote versions" do
-      Ploy::Package.any_instance.should_receive(:`).with(/dpkg-query/) { "abcd\n" }
-      Ploy::S3Storage.any_instance.should_receive(:metadata) { { 'git_revision' => 'bcd' } }
+      expect_any_instance_of(Ploy::Package).to receive(:`).with(/dpkg-query/).and_return("abcd\n")
+      expect_any_instance_of(Ploy::S3Storage).to receive(:metadata).and_return({'git_revision' => 'bcd'})
       expect(@inst.check_new_version).to be true
     end
   end
-
   describe '#location' do # testing gravity here... but it is easy
     it "gives the correct sub-bucket location" do
       expect(@inst.location).to eq(Ploy::Util.remote_name("some-project", "master", "current"))
     end
   end
-
   describe "#bless" do
     it "copies to a blessed location" do
-      Ploy::S3Storage.any_instance.should_receive(:copy).with(
-        Ploy::Util.remote_name("some-project", "master", "current"),
-        Ploy::Util.remote_name("some-project", "master", "current", "blessed")
-      )
+      current = Ploy::Util.remote_name("some-project", "master", "current")
+      blessed = Ploy::Util.remote_name("some-project", "master", "current", "blessed")
+      expect_any_instance_of(Ploy::S3Storage).to receive(:copy).with(current, blessed)
       @inst.bless
     end
   end
-
   describe "#upload" do
     it "uploads a new file" do
-      fakepath = 'foo/bar.deb'
-      Ploy::S3Storage.any_instance.should_receive(:put).with(
-        fakepath, @inst.location, kind_of(Hash)
-      )
-      @inst.upload(fakepath)
+      fake_path = 'foo/bar.deb'
+      expect_any_instance_of(Ploy::S3Storage).to receive(:put).with(fake_path, @inst.location, kind_of(Hash))
+      @inst.upload(fake_path)
     end
   end
-
   describe "#make_current" do
     it "copies this package version to current" do
-      Ploy::S3Storage.any_instance.should_receive(:copy).with(
-        @inst.location,
-        Ploy::Util.remote_name(@inst.deploy_name, @inst.branch, 'current')
-      )
+      package = Ploy::Util.remote_name(@inst.deploy_name, @inst.branch, 'current')
+      expect_any_instance_of(Ploy::S3Storage).to receive(:copy).with(@inst.location, package)
       @inst.make_current
     end
   end
-
   describe "Package.from_metadata" do
     it "returns a list of package objects" do
       meta = {

--- a/spec/s3storage_spec.rb
+++ b/spec/s3storage_spec.rb
@@ -9,29 +9,29 @@ describe Ploy::S3Storage do
   end
   describe "#put" do
     it "uses aws-sdk to upload a file to s3" do
-      fakepath = "nothing.deb"
-      uploadpath = "foo/bar"
+      fake_path = "nothing.deb"
+      upload_path = "foo/bar"
 
       object = double("object")
-      object.should_receive(:write) do | f,opts2 |
+      expect(object).to receive(:write) do |f, opts2|
         expect(f).to be_a(Pathname)
         expect(opts2).to be_a(Hash)
       end
 
       objects = double("objects")
-      objects.should_receive(:[]).with(uploadpath) { object }
+      expect(objects).to receive(:[]).with(upload_path).and_return(object)
 
       bucket = double("bucket")
-      bucket.stub(:objects) { objects }
+      expect(bucket).to receive(:objects).and_return(objects)
 
       buckets = double("buckets")
-      buckets.should_receive(:[]).with("testbucket") { bucket }
+      expect(buckets).to receive(:[]).with("testbucket").and_return(bucket)
 
       s3 = double("s3")
-      s3.should_receive(:buckets) { buckets }
-      AWS::S3.stub(:new) { s3 }
+      expect(s3).to receive(:buckets).and_return(buckets)
+      expect(AWS::S3).to receive(:new).and_return(s3)
       
-      @storage.put(fakepath, uploadpath)
+      @storage.put(fake_path, upload_path)
     end
   end
   describe "#copy" do
@@ -40,51 +40,49 @@ describe Ploy::S3Storage do
       to = "d/e/f"
 
       from_obj = double("from_obj")
-      from_obj.should_receive(:copy_to).with(to)
+      expect(from_obj).to receive(:copy_to).with(to)
 
       objects = double("objects")
-      objects.should_receive(:[]).with(from) { from_obj }
+      expect(objects).to receive(:[]).with(from).and_return(from_obj)
 
       bucket = double("bucket")
-      bucket.stub(:objects) { objects }
+      expect(bucket).to receive(:objects).and_return(objects)
 
       buckets = double("buckets")
-      buckets.should_receive(:[]).with("testbucket") { bucket }
+      expect(buckets).to receive(:[]).with("testbucket").and_return(bucket)
 
       s3 = double("s3")
-      s3.should_receive(:buckets) { buckets }
-      AWS::S3.stub(:new) { s3 }
+      expect(s3).to receive(:buckets).and_return(buckets)
+      expect(AWS::S3).to receive(:new).and_return(s3)
     
       @storage.copy(from, to) 
     end
   end
-
   describe "#read" do
   end
-
   describe "#get" do
     it "downloads a file using aws-sdk" do
       from = "a/b/c"
-      fakeio = double("fakeio")
-      fakeio.should_receive(:flush)
+      fake_io = double("fakeio")
+      expect(fake_io).to receive(:flush)
 
       object = double("object")
-      object.should_receive(:read) { "test" }
+      expect(object).to receive(:read).and_return("test")
     
       objects = double("objects")
-      objects.should_receive(:[]).with(from) { object }
+      expect(objects).to receive(:[]).with(from).and_return(object)
 
       bucket = double("bucket")
-      bucket.stub(:objects) { objects }
+      expect(bucket).to receive(:objects).and_return(objects)
 
       buckets = double("buckets")
-      buckets.should_receive(:[]).with("testbucket") { bucket }
+      expect(buckets).to receive(:[]).with("testbucket").and_return(bucket)
 
       s3 = double("s3")
-      s3.should_receive(:buckets) { buckets }
-      AWS::S3.stub(:new) { s3 }
+      expect(s3).to receive(:buckets).and_return(buckets)
+      expect(AWS::S3).to receive(:new).and_return(s3)
 
-      @storage.get(from, fakeio)
+      @storage.get(from, fake_io)
     end
   end
 end

--- a/spec/yamlreader_spec.rb
+++ b/spec/yamlreader_spec.rb
@@ -23,10 +23,8 @@ describe Ploy::YamlReader do
 #    And  { result['bucket'] == 'bucketname' }
   end
   context "read from HTTP" do
-    When(:result) do
-      Net::HTTP.stub(:get) { ex_str }
-      yr.from_http('http://www.example.com/thing.yml')
-    end
+    Given{ expect(Net::HTTP).to receive(:get).and_return(ex_str) }
+    When(:result){ yr.from_http('http://www.example.com/thing.yml') }
     Then { result['bucket'] == 'bucketname' }
   end
 

--- a/spec/yamlreader_spec.rb
+++ b/spec/yamlreader_spec.rb
@@ -16,11 +16,9 @@ describe Ploy::YamlReader do
     Then { result['bucket'] == 'bucketname' }
   end
   context "read from S3" do
-# any_instance gets errors here for... some reason
-#    Ploy::S3Storage.any_instance.stub(:read) { ex_str }
-#    puts Ploy::S3Storage.any_instance
-#    When(:result) { yr.from_s3('bucket', 'name') }
-#    And  { result['bucket'] == 'bucketname' }
+    Given{ expect_any_instance_of(Ploy::S3Storage).to receive(:read).and_return(ex_str) }
+    When(:result){ yr.from_s3('bucket', 'name') }
+    Then{ result['bucket'] == 'bucketname' }
   end
   context "read from HTTP" do
     Given{ expect(Net::HTTP).to receive(:get).and_return(ex_str) }


### PR DESCRIPTION
This PR fixes the tests to use expect mocking syntax instead of the should syntax that was causing deprecation warnings. 

I didn't change any of the test expectations, but I did get a test from [spec/yamlreader_spec](yamlreader_spec) to work which had previously been commented out.