### PR TITLE
READY: Use bundler gem conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.gem
 *.deb
 quick.sh
+/.bundle/
+/pkg/
+/tmp/
+*.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
-gem 'aws-sdk'
-gem 'fpm'
-gem 'sinatra'
-group :test do
-  gem 'rspec'
-  gem 'rspec-given'
-end
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+PATH
+  remote: .
+  specs:
+    ploy (0.0.23)
+      aws-sdk
+      fpm
+      sinatra
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -8,11 +16,11 @@ GEM
       nokogiri (>= 1.4.4)
     backports (3.6.0)
     cabin (0.6.1)
-    childprocess (0.5.3)
+    childprocess (0.5.5)
       ffi (~> 1.0, >= 1.0.11)
     clamp (0.6.3)
     diff-lcs (1.2.5)
-    ffi (1.9.3)
+    ffi (1.9.6)
     fpm (1.2.0)
       arr-pm (~> 0.0.9)
       backports (>= 2.6.2)
@@ -30,6 +38,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
+    rake (10.3.2)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
@@ -56,8 +65,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk
-  fpm
+  bundler (~> 1.7)
+  ploy!
+  rake (~> 10.0)
   rspec
   rspec-given
-  sinatra

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'bundler/gem_tasks'

--- a/lib/ploy/version.rb
+++ b/lib/ploy/version.rb
@@ -1,0 +1,3 @@
+module Ploy
+  VERSION = "0.0.23"
+end

--- a/ploy.gemspec
+++ b/ploy.gemspec
@@ -1,14 +1,27 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'ploy/version'
+
 Gem::Specification.new do |s|
   s.name = 'ploy'
-  s.version = '0.0.23'
+  s.version = Ploy::VERSION
   s.date = '2013-07-14'
   s.summary = 'Multi-phase deployment tool'
   s.description = 'Multi-phase deployment tool for use in a continuous deployment environment.'
   s.authors = ["Michael Bruce"]
-  s.email = 'mbruce@manta.com'
+  s.email = ['mbruce@manta.com']
+  
   s.files += Dir['lib/**/*.rb']
+  s.test_files += Dir['spec/**/*_spec.rb']
+  s.executables << 'ploy'
+  s.require_paths = ["lib"]
+
   s.add_runtime_dependency 'aws-sdk'
   s.add_runtime_dependency 'fpm'
   s.add_runtime_dependency 'sinatra'
-  s.executables << 'ploy'
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec-given'
+  s.add_development_dependency 'bundler', '~> 1.7'
+  s.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Conversion to bundler gem conventions. Basically, 3 changes:

1. Gemfile points to ploy.gemspec -- which now includes both runtime and development dependencies.
2. Adds ploy/version.rb file, which is the "Ruby" way of versioning.
3. Adds a Rakefile for easy gem management. `rake install` will build and install your local changes to system, which is great for testing. `rake release` will push a tag up to GitHub and release a new version of ploy on rubygems.org.