### PR TITLE
READY: Conf files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    arr-pm (0.0.9)
+    arr-pm (0.0.10)
       cabin (> 0)
     aws-sdk-v1 (1.61.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    backports (3.6.4)
+    backports (3.6.5)
     cabin (0.7.1)
-    childprocess (0.5.5)
+    childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
-    clamp (0.6.3)
+    clamp (0.6.5)
     diff-lcs (1.2.5)
-    ffi (1.9.6)
-    fpm (1.3.3)
-      arr-pm (~> 0.0.9)
+    ffi (1.9.10)
+    fpm (1.4.0)
+      arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
       childprocess
@@ -23,7 +23,7 @@ GEM
       json (>= 1.7.7)
     given_core (3.6.0)
       sorcerer (>= 0.3.7)
-    json (1.8.2)
+    json (1.8.3)
     mini_portile (0.6.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -62,3 +62,6 @@ DEPENDENCIES
   rspec
   rspec-given
   sinatra
+
+BUNDLED WITH
+   1.10.5

--- a/lib/ploy/localpackage/debbuilder.rb
+++ b/lib/ploy/localpackage/debbuilder.rb
@@ -50,6 +50,7 @@ module Ploy
           { "-C" => dir },
           { "--deb-field" => "'gitrev: #{@sha}'" },
           "-f",
+          "--deb-no-default-config-files",
           { "-v" => safeversion(@timestamp + '.' + @branch) },
         ]
 

--- a/ploy.gemspec
+++ b/ploy.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name = 'ploy'
-  s.version = '0.0.33'
+  s.version = '0.0.34'
   s.date = '2013-07-14'
   s.summary = 'Multi-phase deployment tool'
   s.description = 'Multi-phase deployment tool for use in a continuous deployment environment.'
-  s.authors = ["Michael Bruce"]
+  s.authors = ["Michael Bruce", "Brian J. Schrock"]
   s.email = 'mbruce@manta.com'
   s.files += Dir['lib/**/*.rb']
   s.add_runtime_dependency 'aws-sdk-v1'


### PR DESCRIPTION
This pull request tells fpm to ignore conf files that are in /etc.Essentially reverting version 1.4.0 back to what 1.3.3 did by default.