### PR TITLE
Add: Update ploy publish to include systemd files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,16 @@ dist_dirs:
 prep_cmd: lineman build
 upstart_files:
  - conf/some-project-initfile
+systemd_files:
+ - conf/some-project-sysfile
+mnt_log_path: path/to/service/logs
 postinst: |
   # This script will be in /var/lib/dpkg/info/${PACKAGE_NAME}.postinst
   # once the package is installed. Ploy adds #!/bin/bash to the top
   # automatically.
 ```
+**Note:**
+`systemd_files` and `mnt_log_path` are necessary if you want to install the service using systemd. If you don't want to use systemd, you can ignore these fields.
 
 ### metadata files
 

--- a/lib/ploy/localpackage/config.rb
+++ b/lib/ploy/localpackage/config.rb
@@ -14,6 +14,8 @@ module Ploy
           :branch        => git_branch,
           :timestamp     => git_timestamp,
           :upstart_files => @conf['upstart_files'],
+          :systemd_files => @conf['systemd_files'],
+          :mnt_log_path  => @conf['mnt_log_path'],
           :dist_dirs     => @conf['dist_dirs'],
           :dist_dir      => @conf['dist_dir'],
           :prefix        => @conf['prefix'],

--- a/lib/ploy/localpackage/debbuilder.rb
+++ b/lib/ploy/localpackage/debbuilder.rb
@@ -10,6 +10,8 @@ module Ploy
       attr_accessor :branch
       attr_accessor :timestamp
       attr_accessor :upstart_files
+      attr_accessor :systemd_files
+      attr_accessor :mnt_log_path
       attr_accessor :dist_dirs
       attr_accessor :dist_dir
       attr_accessor :prefix
@@ -35,7 +37,9 @@ module Ploy
             ol = fpm_optlist(dir)
             ol.add("--after-install", file.path)
             #puts "debug: fpm #{ol.as_string} ."
-            info = eval(`fpm #{ol.as_string} .`)
+            output = `fpm #{ol.as_string} .`
+            output = output.gsub("Adding action files", "")
+            info = eval(output)
           end
         end
         return info[:path]
@@ -54,12 +58,20 @@ module Ploy
           { "-v" => safeversion(@timestamp + '.' + @branch) },
         ]
 
-        if @upstart_files then
+        if @upstart_files && !@systemd_files then
           @upstart_files.each do | upstart |
             optlist.add("--deb-upstart", upstart)
           end
         end
 
+        if @systemd_files then
+          @systemd_files.each do | systemd |
+            optlist.add("--deb-systemd", systemd)
+            optlist.add("--deb-systemd-auto-start", "")
+            optlist.add("--deb-systemd-restart-after-upgrade", "")
+            optlist.add("--deb-systemd-enable", "")
+          end
+        end
         return optlist
       end
 
@@ -90,7 +102,7 @@ module Ploy
 # END PACKAGE POSTINST
 SCRIPT
 
-        if @upstart_files then
+        if @upstart_files && !@systemd_files then
           @upstart_files.each do | upstart |
             service = File.basename(upstart)
             file.write <<SCRIPT
@@ -105,6 +117,16 @@ if check_upstart_service #{service}; then
   stop #{service}
 fi
 start #{service}
+SCRIPT
+          end
+        elsif @systemd_files then
+          @systemd_files.each do | systemd |
+            service = File.basename(systemd)
+            mnt_log = @mnt_log_path ? @mnt_log_path : "/mnt/" + service
+            file.write <<SCRIPT
+# Systemd after script
+mkdir -p #{mnt_log}
+
 SCRIPT
           end
         end


### PR DESCRIPTION
## Description of Changes
This change adds support for the creation of deb packages compatible with the systemd service manager.

To publish a deb package for systemd, you have to add the following new fields to the `.ploy_publisher.yml`file.

* **systemd_files**: a list of paths where the systemd .service file is located
* **mnt_log_path (optional)**: This configuration is to declare where the service logs will be located. By default:`/mnt/SERVICE_NAME`
Example:
```yml
systemd_files:
  - ../service-a/init/service-a.service
mnt_log_path: /mnt/service-a
```

## Testing
### Setup
1. Clone the ploy code in a ubuntu server
2. Run the following script to install the dependencies
```bash
gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
curl -sSL https://get.rvm.io | bash -s stable
source ~/.zshrc
rvm pkg install openssl
rvm install 2.4.1 --with-openssl-dir=$HOME/.rvm/usr
bash --login
rvm use 2.4.1
gem install bundler:2.2.17
bundle install
```
3. Comment lines 14->16 in [lib/ploy/publisher.rb](https://github.com/mantacode/ploy/blob/28acdea868f4c3f10cd28f968947b5271151f5fc/lib/ploy/publisher.rb#L14) file, to avoid publishing packages to S3.

### Systemd 
1. Configure the .ploy_publisher.yml file adding the two new options:
* **systemd_files**: a list of paths where the systemd .service file is located
* **mnt_log_path (optional)**: This configuration is to declare where the service logs will be located
Example:
```yml
upstart_files:
  - ../service-a/init/service-a
systemd_files:
  - ../service-a/init/service-a.service
mnt_log_path: /mnt/service-a
```
2. Execute the ploy publish command:
```bash
env RUBYLIB=./lib bundle exec bin/ploy publish PATH_TO_PLOY_PUBLISHER_YML
```
3. The deb package will be stored in the current path.
4. Copy the deb package to a ubuntu server with systemd service manager.
5. Install the package with the following command 
```
sudo dpkg -i DEB_PACKAGE
```
6. Verify that the service is running:
```bash
systemctl status SERVICE_NAME
``` 
### Upstart
1. Configure the .ploy_publisher.yml file without the two new options:
* **systemd_files**: a list of paths where the systemd .service file is located
* **mnt_log_path (optional)**: This configuration is to declare where the service logs will be located
Example:
```yml
upstart_files:
  - ../service-a/init/service-a
```
2. Execute the ploy publish command:
```bash
env RUBYLIB=./lib bundle exec bin/ploy publish PATH_TO_PLOY_PUBLISHER_YML
```
3. The deb package will be stored in the current path.
4. Copy the deb package to a ubuntu server with upstart service manager.
5. Install the package with the following command 
```
sudo dpkg -i DEB_PACKAGE
```
6. Verify that the service is running:
```bash
service SERVICE_NAME status
``` 